### PR TITLE
Issue #7: Checking ContentType

### DIFF
--- a/src/Providers/MailerAbstract.php
+++ b/src/Providers/MailerAbstract.php
@@ -105,12 +105,16 @@ abstract class MailerAbstract implements MailerInterface {
 			)
 		);
 		$this->set_subject( $this->phpmailer->Subject );
-		$this->set_content(
-			array(
-				'html' => $this->phpmailer->Body,
-				'text' => $this->phpmailer->AltBody,
-			)
-		);
+		if ($this->phpmailer->ContentType == 'text/html') {
+			$this->set_content(
+				array(
+					'html' => $this->phpmailer->Body,
+					'text' => $this->phpmailer->AltBody,
+				)
+			);
+		} else {
+			$this->set_content($this->phpmailer->Body);
+		}
 		$this->set_return_path( $this->phpmailer->From );
 		$this->set_reply_to( $this->phpmailer->getReplyToAddresses() );
 

--- a/src/Providers/MailerAbstract.php
+++ b/src/Providers/MailerAbstract.php
@@ -105,7 +105,7 @@ abstract class MailerAbstract implements MailerInterface {
 			)
 		);
 		$this->set_subject( $this->phpmailer->Subject );
-		if ($this->phpmailer->ContentType == 'text/html') {
+		if ( $this->phpmailer->ContentType === 'text/html' ) {
 			$this->set_content(
 				array(
 					'text' => $this->phpmailer->AltBody,
@@ -115,7 +115,6 @@ abstract class MailerAbstract implements MailerInterface {
 		} else {
 			$this->set_content($this->phpmailer->Body);
 		}
-
 		$this->set_return_path( $this->phpmailer->From );
 		$this->set_reply_to( $this->phpmailer->getReplyToAddresses() );
 

--- a/src/Providers/MailerAbstract.php
+++ b/src/Providers/MailerAbstract.php
@@ -107,8 +107,8 @@ abstract class MailerAbstract implements MailerInterface {
 		$this->set_subject( $this->phpmailer->Subject );
 		$this->set_content(
 			array(
-				'html' => $this->phpmailer->Body,
 				'text' => $this->phpmailer->AltBody,
+				'html' => $this->phpmailer->Body,
 			)
 		);
 		$this->set_return_path( $this->phpmailer->From );

--- a/src/Providers/Mailgun/Mailer.php
+++ b/src/Providers/Mailgun/Mailer.php
@@ -190,7 +190,7 @@ class Mailer extends MailerAbstract {
 
 			$data[] = array(
 				'content' => $file,
-				'name'    => $attachment[1],
+				'name'    => $attachment[2],
 			);
 		}
 


### PR DESCRIPTION
Checking ContentType of email before passing array. Plain text emails expect a string, html emails expect an array. 

## Description

Per #7

## Testing procedure

Didn't see any unit tests. Tested locally by following the replication steps from Issue #7.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (modification of the currently available functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My code has appropriate phpdoc comments with a description, `@since`, `@params` and `@return`.
- [ ] My code is tested for both new installs and for users that are upgrading from older versions.